### PR TITLE
Fix model persistence

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -48,11 +48,11 @@ func Login(w http.ResponseWriter, r *http.Request) {
 // Signup - user signup handler
 func Signup(w http.ResponseWriter, r *http.Request) {
 	hashedPassword, _ := HashPassword("password")
-	userData := UserDTO{
+	userData := MakeDTO(UserDTO{
 		id:       uuid.New().String(),
 		password: hashedPassword,
 		email:    "jsamchineme@gmail.com",
-	}
+	})
 
 	u, err := UserRepo.CreateRecord(userData)
 	if err != nil {
@@ -60,7 +60,7 @@ func Signup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	fmt.Println("NewUser\n", u)
+	fmt.Println("NewUser\n", u, UserModel.getTableData())
 }
 
 // TokenVerifyMiddleware handles token verification

--- a/auth.go
+++ b/auth.go
@@ -60,8 +60,8 @@ func Signup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	usrd := UserModel.getTableData().([]ModelDTO)
-	fmt.Println("Users\n", usrd)
+	rows := UserModel.getTableData()
+	fmt.Println("Users\n", rows)
 }
 
 // TokenVerifyMiddleware handles token verification

--- a/auth.go
+++ b/auth.go
@@ -54,13 +54,14 @@ func Signup(w http.ResponseWriter, r *http.Request) {
 		email:    "jsamchineme@gmail.com",
 	})
 
-	u, err := UserRepo.CreateRecord(userData)
+	_, err := UserRepo.CreateRecord(userData)
 	if err != nil {
 		fmt.Println(err)
 		return
 	}
 
-	fmt.Println("NewUser\n", u, UserModel.getTableData())
+	usrd := UserModel.getTableData().([]ModelDTO)
+	fmt.Println("Users\n", usrd)
 }
 
 // TokenVerifyMiddleware handles token verification

--- a/main.go
+++ b/main.go
@@ -21,9 +21,7 @@ type Error struct {
 }
 
 func main() {
-	UserModel.initialiseTable()
-	d := UserRepo.getTableData()
-	fmt.Println(d)
+	setupDB()
 
 	router := mux.NewRouter()
 
@@ -33,6 +31,13 @@ func main() {
 
 	log.Println("Listen on port 8000...")
 	log.Fatal(http.ListenAndServe(":8000", router))
+}
+
+func setupDB() {
+	UserModel.initialiseTable()
+	d := UserRepo.getTableData()
+
+	fmt.Println("\nUsers:\n\n", d)
 }
 
 func protectedEndpoint(w http.ResponseWriter, r *http.Request) {

--- a/model.go
+++ b/model.go
@@ -9,7 +9,8 @@ type Model struct {
 // TableReader setups a table for managing a Model's data
 type TableReader interface {
 	getTableName() string
-	getTableData() interface{}
+	getTableData() []ModelDTO
+	setTableData([]ModelDTO)
 }
 
 // ModelDTO - the data transfer object for a model
@@ -34,8 +35,9 @@ func MakeDTO(t IsDTO) ModelDTO {
 
 // CreateRecord is used to insert a new row into a table
 func (m Model) CreateRecord(d ModelDTO) (ModelDTO, error) {
-	rows := m.getTableData().([]ModelDTO)
+	rows := m.getTableData()
 	rows = append(rows, d)
+	m.setTableData(rows)
 
 	return d, nil
 }

--- a/model.go
+++ b/model.go
@@ -35,12 +35,7 @@ func MakeDTO(t IsDTO) ModelDTO {
 // CreateRecord is used to insert a new row into a table
 func (m Model) CreateRecord(d ModelDTO) (ModelDTO, error) {
 	rows := m.getTableData().([]ModelDTO)
-
-	// update the rows for the model's table
 	rows = append(rows, d)
 
 	return d, nil
-}
-
-func (m Model) setTableData(d interface{}) {
 }

--- a/model.go
+++ b/model.go
@@ -13,18 +13,30 @@ type TableReader interface {
 }
 
 // ModelDTO - the data transfer object for a model
-type ModelDTO interface {
+type ModelDTO struct {
+	IsDTO
+}
+
+// IsDTO marks an object as DTO
+type IsDTO interface {
 	getID() string
 }
 
-// NewModel - Factory for generating models
+// NewModel - factory for generating models
 func NewModel(t TableReader) Model {
 	return Model{t}
+}
+
+// MakeDTO - factory to generate a ModelDTO
+func MakeDTO(t IsDTO) ModelDTO {
+	return ModelDTO{t}
 }
 
 // CreateRecord is used to insert a new row into a table
 func (m Model) CreateRecord(d ModelDTO) (ModelDTO, error) {
 	rows := m.getTableData().([]ModelDTO)
+
+	// update the rows for the model's table
 	rows = append(rows, d)
 
 	return d, nil

--- a/user.go
+++ b/user.go
@@ -29,13 +29,18 @@ func (user UserDTO) getID() string {
 }
 
 // Model implementation MUST have this
-func (u User) getTableData() interface{} {
+func (u User) getTableData() []ModelDTO {
 	return users
 }
 
 // Model implementation MUST have this
 func (User) getTableName() string {
 	return "users"
+}
+
+// Model implementation MUST have this
+func (User) setTableData(data []ModelDTO) {
+	users = data
 }
 
 func makeDTO(t UserDTO) ModelDTO {
@@ -70,6 +75,5 @@ func (User) initialiseTable() {
 			password: hashedPassword,
 		})
 		UserRepo.CreateRecord(d)
-		// users = append(users, d)
 	}
 }

--- a/user.go
+++ b/user.go
@@ -15,7 +15,7 @@ type UserDTO struct {
 	password string
 }
 
-var users = &[]ModelDTO{}
+var users = []ModelDTO{}
 
 // UserModel - user model instance
 var UserModel = &User{}
@@ -30,7 +30,7 @@ func (user UserDTO) getID() string {
 
 // Model implementation MUST have this
 func (u User) getTableData() interface{} {
-	return *users
+	return users
 }
 
 // Model implementation MUST have this
@@ -43,8 +43,7 @@ func makeDTO(t UserDTO) ModelDTO {
 }
 
 func (User) initialiseTable() {
-
-	dummy := []UserDTO{
+	seed := []UserDTO{
 		UserDTO{
 			id:       uuid.New().String(),
 			email:    "jsamchineme@example.test",
@@ -62,21 +61,15 @@ func (User) initialiseTable() {
 		},
 	}
 
-	// to update a property of "user" by refering to it like so - "for i, user := range users" would not work
-	// because range creates a copy of the user item from the splice,
-	// hence the syntax below - user := &users[i], this user value is now a pointer that can be updated
-
-	for _, user := range dummy {
-		// There's the need to wrap this block within the type assertion for User
-		// because each user is seen as an Entity type
-		// Wrapping the code in the assertion block makes it so that the "u" variable refers to a User type
-		// which will then make field password, email accessible
+	for i := range seed {
+		user := seed[i]
 		hashedPassword, _ := HashPassword(user.password)
-		userData := MakeDTO(UserDTO{
-			id:       uuid.New().String(),
+		d := MakeDTO(UserDTO{
+			id:       user.id,
+			email:    user.email,
 			password: hashedPassword,
-			email:    "jsamchineme@gmail.com",
 		})
-		UserRepo.CreateRecord(userData)
+		UserRepo.CreateRecord(d)
+		// users = append(users, d)
 	}
 }

--- a/user.go
+++ b/user.go
@@ -15,7 +15,7 @@ type UserDTO struct {
 	password string
 }
 
-var users = []UserDTO{}
+var users = &[]ModelDTO{}
 
 // UserModel - user model instance
 var UserModel = &User{}
@@ -23,14 +23,14 @@ var UserModel = &User{}
 // UserRepo - for data store access
 var UserRepo = NewModel(User{})
 
-// ModelDTO implementation MUST have this
+// Model.isDTO implementation MUST have this
 func (user UserDTO) getID() string {
 	return user.id
 }
 
-// ModelDTO implementation MUST have this
+// Model implementation MUST have this
 func (u User) getTableData() interface{} {
-	return &users
+	return *users
 }
 
 // Model implementation MUST have this
@@ -38,8 +38,13 @@ func (User) getTableName() string {
 	return "users"
 }
 
+func makeDTO(t UserDTO) ModelDTO {
+	return ModelDTO{t}
+}
+
 func (User) initialiseTable() {
-	users = []UserDTO{
+
+	dummy := []UserDTO{
 		UserDTO{
 			id:       uuid.New().String(),
 			email:    "jsamchineme@example.test",
@@ -60,15 +65,18 @@ func (User) initialiseTable() {
 	// to update a property of "user" by refering to it like so - "for i, user := range users" would not work
 	// because range creates a copy of the user item from the splice,
 	// hence the syntax below - user := &users[i], this user value is now a pointer that can be updated
-	for i := range users {
+
+	for _, user := range dummy {
 		// There's the need to wrap this block within the type assertion for User
 		// because each user is seen as an Entity type
 		// Wrapping the code in the assertion block makes it so that the "u" variable refers to a User type
 		// which will then make field password, email accessible
-		user := &users[i]
-
 		hashedPassword, _ := HashPassword(user.password)
-
-		user.password = string(hashedPassword)
+		userData := MakeDTO(UserDTO{
+			id:       uuid.New().String(),
+			password: hashedPassword,
+			email:    "jsamchineme@gmail.com",
+		})
+		UserRepo.CreateRecord(userData)
 	}
 }


### PR DESCRIPTION
This adds a new method which all `Models` like `User` model must use to update the array of records after a new record is appended into the array(slice). I introduce this extra method after having difficulties with referring to the `users` (array) pointer in the Model.CreateRecord method.
So, this works now. However, being that I am just starting out learning Go. I am wondering if there is a pattern that achieves the same effect **without introducing the new setTableData() method in all Model implementations** 